### PR TITLE
Overhaul of experiment deployment infrastructure

### DIFF
--- a/expdj/apps/experiments/static/js/jquery_boostrap_modal_steps.js
+++ b/expdj/apps/experiments/static/js/jquery_boostrap_modal_steps.js
@@ -13,7 +13,9 @@
             completeCallback: function(){
               $("#start_experiment_button").click();
             },
-            callbacks: {}
+            callbacks: function(){
+              $("#start_experiment").click();
+            }
         }, options);
 
 

--- a/expdj/apps/experiments/templates/experiments/battery_details.html
+++ b/expdj/apps/experiments/templates/experiments/battery_details.html
@@ -34,7 +34,7 @@
             <div class="float_right">
                 {% if edit_permission %}
                     {% if battery.experiments.all and mturk_permission %}
-                        <a class='btn-default btn-lg' href='{% url 'multiple_new_hit' battery.id %}'> Batch HITs</a>
+                        <!--<a class='btn-default btn-lg' href='{% url 'multiple_new_hit' battery.id %}'> Batch HITs</a>-->
                         <a class='btn-default btn-lg' href='{% url 'new_hit' battery.id %}'> New HIT</a>
                     {% endif %}
                     {% if battery.experiments.all %}

--- a/expdj/apps/experiments/templates/experiments/battery_details.html
+++ b/expdj/apps/experiments/templates/experiments/battery_details.html
@@ -16,18 +16,18 @@
                 {% endif %}
                 {% if mturk_permission %}
                     {% if hits %}
-                        <a class='btn-default btn-lg' target="_blank" href='{% url 'serve_hit' hits.0.id %}'>Preview</a>
+                        <a class='btn-default btn-lg' target="_blank" href='{% url 'preview_battery' battery.id %}'>Preview</a>
                     {% endif %}
                 {% endif %}
             {% else %}
                 {% if mturk_permission %}
                 {% if hits %}
                 <div class="alert alert-info" role="alert">You do not have permission to edit this battery, but you can
-                <a href='{% url 'serve_hit' hits.0.id %}' target="_blank">preview</a> it.</div>
+                <a href='{% url 'preview_battery' battery.id %}' target="_blank">preview</a> it.</div>
                 {% endif %}
                 {% else %}
                 <div class="alert alert-info" role="alert">You do not have permission to edit this battery, but you can
-                <a href='{% url 'serve_battery' battery.id %}' target="_blank">preview</a> it.</div>
+                <a href='{% url 'preview_battery' battery.id %}' target="_blank">preview</a> it.</div>
                 {% endif %}
             {% endif %}
 

--- a/expdj/apps/experiments/templates/experiments/serve_battery.html
+++ b/expdj/apps/experiments/templates/experiments/serve_battery.html
@@ -14,14 +14,11 @@
 
 {% include "experiments/serve_battery_runjs.html" %}
 
-{% if instruction_forms %}
-    {% include "experiments/instructions_modal.html" %}
-{% else %}
 <script>
-$(function() {
-    $("#start_experiment_button").click();
+$(document).ready(function(){
+   $("#start_experiment_button").click();
 });
 </script>
-{% endif %}
-  </body>
+
+</body>
 </html>

--- a/expdj/apps/experiments/urls.py
+++ b/expdj/apps/experiments/urls.py
@@ -5,7 +5,7 @@ edit_battery, view_battery, delete_battery, export_battery, remove_experiment, \
 add_experiment, edit_experiment, save_experiment, update_experiment_template, \
 remove_condition, preview_battery, serve_battery, serve_battery_anon, \
 generate_battery_user, localsync, experiment_results_dashboard, \
-battery_results_dashboard, modify_experiment
+battery_results_dashboard, dummy_battery ,modify_experiment, intro_battery
 from expdj import settings
 from django.views.generic.base import TemplateView
 from django.conf.urls import patterns, url
@@ -47,8 +47,9 @@ urlpatterns = patterns('',
     url(r'^batteries/(?P<bid>\d+|[A-Z]{8})/export$',export_battery,name='export_battery'),
 
     # Deployment
-    #url(r'^batteries/(?P<bid>\d+|[A-Z]{8})/serve$',preview_battery,name='preview_battery'), # preview without subid
-    url(r'^batteries/(?P<bid>\d+|[A-Z]{8})/(?P<userid>\d+|[A-Za-z0-9-]{36})/serve$',preview_battery,name='preview_battery'),
+    url(r'^batteries/(?P<bid>\d+|[A-Z]{8})/preview$',preview_battery,name='preview_battery'), # intro preview without subid
+    url(r'^batteries/(?P<bid>\d+|[A-Z]{8})/dummy$',dummy_battery,name='dummy_battery'),       # running without subid
+    url(r'^batteries/(?P<bid>\d+|[A-Z]{8})/(?P<userid>\d+|[A-Za-z0-9-]{36})/serve$',intro_battery,name='intro_battery'),
     url(r'^batteries/(?P<bid>\d+|[A-Z]{8})/(?P<userid>\d+|[A-Za-z0-9-]{36})/accept$',serve_battery,name='serve_battery'),
     url(r'^batteries/(?P<bid>\d+|[A-Z]{8})/(?P<keyid>\d+|[A-Za-z0-9-]{32})/anon$',serve_battery_anon,name='serve_battery_anon'),
     url(r'^local/(?P<rid>\d+|[A-Z]{8})/$',localsync,name='local'),

--- a/expdj/apps/experiments/urls.py
+++ b/expdj/apps/experiments/urls.py
@@ -41,12 +41,14 @@ urlpatterns = patterns('',
     url(r'^batteries/(?P<bid>\d+|[A-Z]{8})/edit$',edit_battery,name='edit_battery'),
     url(r'^batteries/(?P<bid>\d+|[A-Z]{8})/user$',generate_battery_user,name='generate_battery_user'),
     #url(r'^batteries/(?P<bid>\d+|[A-Z]{8})/results$',battery_results_dashboard,name='battery_results_dashboard'),
-    url(r'^batteries/(?P<bid>\d+|[A-Z]{8})/serve$',serve_battery,name='serve_battery'), # preview
-    url(r'^batteries/(?P<bid>\d+|[A-Z]{8})/(?P<userid>\d+|[A-Za-z0-9-]{36})/serve$',serve_battery,name='serve_battery'),
-    url(r'^batteries/(?P<bid>\d+|[A-Z]{8})/(?P<keyid>\d+|[A-Za-z0-9-]{32})/anon$',serve_battery_anon,name='serve_battery_anon'),
     url(r'^batteries/(?P<bid>\d+|[A-Z]{8})/$',view_battery, name='battery_details'),
     url(r'^batteries/(?P<bid>\d+|[A-Z]{8})/delete$',delete_battery,name='delete_battery'),
     url(r'^batteries/(?P<bid>\d+|[A-Z]{8})/export$',export_battery,name='export_battery'),
+
+    # Deployment
+    url(r'^batteries/(?P<bid>\d+|[A-Z]{8})/serve$',serve_battery,name='serve_battery'), # preview
+    url(r'^batteries/(?P<bid>\d+|[A-Z]{8})/(?P<userid>\d+|[A-Za-z0-9-]{36})/serve$',serve_battery,name='serve_battery'),
+    url(r'^batteries/(?P<bid>\d+|[A-Z]{8})/(?P<keyid>\d+|[A-Za-z0-9-]{32})/anon$',serve_battery_anon,name='serve_battery_anon'),
     url(r'^local/(?P<rid>\d+|[A-Z]{8})/$',localsync,name='local'),
     url(r'^local/$',localsync,name='local')) # local sync of data
 

--- a/expdj/apps/experiments/urls.py
+++ b/expdj/apps/experiments/urls.py
@@ -3,8 +3,9 @@ delete_experiment_template, add_experiment_template, save_experiment_template, \
 view_experiment, export_experiment, preview_experiment, batteries_view, add_battery, \
 edit_battery, view_battery, delete_battery, export_battery, remove_experiment, \
 add_experiment, edit_experiment, save_experiment, update_experiment_template, \
-remove_condition, serve_battery, serve_battery_anon, generate_battery_user, localsync, \
-experiment_results_dashboard, battery_results_dashboard, modify_experiment
+remove_condition, preview_battery, serve_battery, serve_battery_anon, \
+generate_battery_user, localsync, experiment_results_dashboard, \
+battery_results_dashboard, modify_experiment
 from expdj import settings
 from django.views.generic.base import TemplateView
 from django.conf.urls import patterns, url
@@ -46,8 +47,9 @@ urlpatterns = patterns('',
     url(r'^batteries/(?P<bid>\d+|[A-Z]{8})/export$',export_battery,name='export_battery'),
 
     # Deployment
-    url(r'^batteries/(?P<bid>\d+|[A-Z]{8})/serve$',serve_battery,name='serve_battery'), # preview
-    url(r'^batteries/(?P<bid>\d+|[A-Z]{8})/(?P<userid>\d+|[A-Za-z0-9-]{36})/serve$',serve_battery,name='serve_battery'),
+    #url(r'^batteries/(?P<bid>\d+|[A-Z]{8})/serve$',preview_battery,name='preview_battery'), # preview without subid
+    url(r'^batteries/(?P<bid>\d+|[A-Z]{8})/(?P<userid>\d+|[A-Za-z0-9-]{36})/serve$',preview_battery,name='preview_battery'),
+    url(r'^batteries/(?P<bid>\d+|[A-Z]{8})/(?P<userid>\d+|[A-Za-z0-9-]{36})/accept$',serve_battery,name='serve_battery'),
     url(r'^batteries/(?P<bid>\d+|[A-Z]{8})/(?P<keyid>\d+|[A-Za-z0-9-]{32})/anon$',serve_battery_anon,name='serve_battery_anon'),
     url(r'^local/(?P<rid>\d+|[A-Z]{8})/$',localsync,name='local'),
     url(r'^local/$',localsync,name='local')) # local sync of data

--- a/expdj/apps/experiments/views.py
+++ b/expdj/apps/experiments/views.py
@@ -245,6 +245,7 @@ def generate_battery_user(request,bid):
     else:
             return HttpResponseRedirect(battery.get_absolute_url())
 
+
 def serve_battery_anon(request,bid,keyid):
     '''serve an anonymous local battery, userid is generated upon going to link'''
     # Check if the keyid is correct
@@ -257,7 +258,9 @@ def serve_battery_anon(request,bid,keyid):
     else:
         return render_to_response("turk/robot_sorry.html")
 
+
 def serve_battery(request,bid,userid=None):
+    '''prepare for local serve of battery'''
 
     battery = get_battery(bid,request)
     next_page = None

--- a/expdj/apps/turk/templates/turk/mturk_battery.html
+++ b/expdj/apps/turk/templates/turk/mturk_battery.html
@@ -14,27 +14,16 @@
 
 {% include "experiments/serve_battery_runjs.html" %}
 
-<!-- This should have an if..-->
-<div id="mturk_preview_message">
- <div class="alert alert-info" style="font-size:26px; height:200px; padding-top:75px; padding-left:300px">You must participate in the experiment to view the content.</div>
-</div>
-
-
 <form action="{{ amazon_host }}" method="POST" id="turkey_form">
         <input type="hidden" id="assignmentId" value="{{ assignment_id }}" name="assignmentId"/>
         <input type="hidden" id="workerId" value="{{ worker_id }}" name="workerId"/>
         <input type="hidden" id="hitId" value="{{ hit_id }}" name="hitId"/>
 </form>
 
-{% if instruction_forms %}
-    {% include "experiments/instructions_modal.html" %}
-{% else %}
 <script>
-$(function() {
-    $("#start_experiment_button").click();
+$(document).ready(function(){
+   $("#start_experiment_button").click();
 });
 </script>
-{% endif %}
-
   </body>
 </html>

--- a/expdj/apps/turk/templates/turk/mturk_battery.html
+++ b/expdj/apps/turk/templates/turk/mturk_battery.html
@@ -14,6 +14,12 @@
 
 {% include "experiments/serve_battery_runjs.html" %}
 
+<!-- This should have an if..-->
+<div id="mturk_preview_message">
+ <div class="alert alert-info" style="font-size:26px; height:200px; padding-top:75px; padding-left:300px">You must participate in the experiment to view the content.</div>
+</div>
+
+
 <form action="{{ amazon_host }}" method="POST" id="turkey_form">
         <input type="hidden" id="assignmentId" value="{{ assignment_id }}" name="assignmentId"/>
         <input type="hidden" id="workerId" value="{{ worker_id }}" name="workerId"/>

--- a/expdj/apps/turk/templates/turk/mturk_battery_preview.html
+++ b/expdj/apps/turk/templates/turk/mturk_battery_preview.html
@@ -4,6 +4,7 @@
     <title>The Experiment Factory</title>
     <meta charset="utf-8" />
     <script src="{% static "js/jquery.min.js"%}"></script>
+    <link rel="stylesheet" href="{% static "css/bootstrap.css"%}" />
     <script src="{% static "js/bootstrap.min.js"%}"></script>
 </head>
 <body>

--- a/expdj/apps/turk/templates/turk/mturk_battery_preview.html
+++ b/expdj/apps/turk/templates/turk/mturk_battery_preview.html
@@ -5,33 +5,11 @@
     <meta charset="utf-8" />
     <script src="{% static "js/jquery.min.js"%}"></script>
     <script src="{% static "js/bootstrap.min.js"%}"></script>
-    <script type="text/javascript" src="/static/expdjjs/underscore-min.js"></script>
-    <script type="text/javascript" src="/static/expdjjs/backbone-min.js"></script>
-    <script type="text/javascript" src="/static/expdjjs/expfactory.js"></script>
-    {{ experiment_load | safe }}
-
 </head>
 <body>
 
-<div id="mturk_preview_message">
- <div class="alert alert-info" style="font-size:26px; height:200px; padding-top:75px; padding-left:300px">You must participate in the experiment to view the content.</div>
-</div>
-
-
-    {% include "experiments/instructions_modal.html" %}
-
-    <script>
-
-    $(function() {
-
-      {% include "experiments/preview_battery_runjs.html" %}
-
-      $("#start_experiment_button").click(function(){
-         $("#instructions_modal").hide();
-      });
-
-   });
-</script>
-
+    <div id="mturk_preview_message">
+        <div class="alert alert-info" style="font-size:26px; height:200px; padding-top:75px; padding-left:300px">You must participate in the experiment to view the content.</div>
+    </div>
   </body>
 </html>

--- a/expdj/apps/turk/templates/turk/serve_battery_intro.html
+++ b/expdj/apps/turk/templates/turk/serve_battery_intro.html
@@ -1,0 +1,37 @@
+<html>
+{% load static from staticfiles %}
+  <head>
+    <title>The Experiment Factory</title>
+    <meta charset="utf-8" />
+    <script src="{% static "js/jquery.min.js"%}"></script>
+    <script src="{% static "js/bootstrap.min.js"%}"></script>
+</head>
+<body>
+
+{% include "experiments/instructions_modal.html" %}
+
+<button id="start_experiment" hidden></button>
+
+<script>
+$(document).ready(function(){
+
+    var complete = "1";
+    $("#next_button").click(function() {
+
+        console.log(complete)
+        if (complete == "complete"){
+
+            {% if assignment_id %}
+                window.open("/turk/{{ hit_uid }}?assignmentId={{ assignment_id }}&workerId={{ worker_id }}&turkSubmitTo={{ turk_submit_to }}&hitId={{ hit_id }}")
+            {% else %}
+                window.open("{% url 'not_consent_view' %}",fullscreen=1)
+            {% endif %}
+        }
+        complete = $("#next_button").attr("data-step")
+    });
+
+});
+</script>
+
+</body>
+</html>

--- a/expdj/apps/turk/templates/turk/serve_battery_intro.html
+++ b/expdj/apps/turk/templates/turk/serve_battery_intro.html
@@ -21,7 +21,7 @@ $(document).ready(function(){
         if (complete == "complete"){
 
             {% if assignment_id %}
-                window.open("/accept/{{ hit_uid }}/accept?assignmentId={{ assignment_id }}&workerId={{ worker_id }}&turkSubmitTo={{ turk_submit_to }}&hitId={{ hit_id }}")
+                window.open("{{ start_url }}")
             {% else %}
                 window.open("{% url 'not_consent_view' %}",fullscreen=1)
             {% endif %}

--- a/expdj/apps/turk/templates/turk/serve_battery_intro.html
+++ b/expdj/apps/turk/templates/turk/serve_battery_intro.html
@@ -18,11 +18,10 @@ $(document).ready(function(){
     var complete = "1";
     $("#next_button").click(function() {
 
-        console.log(complete)
         if (complete == "complete"){
 
             {% if assignment_id %}
-                window.open("/turk/{{ hit_uid }}?assignmentId={{ assignment_id }}&workerId={{ worker_id }}&turkSubmitTo={{ turk_submit_to }}&hitId={{ hit_id }}")
+                window.open("/accept/{{ hit_uid }}/accept?assignmentId={{ assignment_id }}&workerId={{ worker_id }}&turkSubmitTo={{ turk_submit_to }}&hitId={{ hit_id }}")
             {% else %}
                 window.open("{% url 'not_consent_view' %}",fullscreen=1)
             {% endif %}

--- a/expdj/apps/turk/urls.py
+++ b/expdj/apps/turk/urls.py
@@ -1,5 +1,5 @@
-from expdj.apps.turk.views import edit_hit, delete_hit, expire_hit, serve_hit, \
- multiple_new_hit, sync, end_assignment, finished_view, not_consent_view
+from expdj.apps.turk.views import edit_hit, delete_hit, expire_hit, preview_hit, \
+serve_hit, multiple_new_hit, sync, end_assignment, finished_view, not_consent_view
 from django.views.generic.base import TemplateView
 from django.conf.urls import patterns, url
 
@@ -12,7 +12,8 @@ urlpatterns = patterns('',
     url(r'^hits/(?P<hid>\d+|[A-Z]{8})/expire$',expire_hit,name='expire_hit'),
 
     # Turk Deployments
-    url(r'^turk/(?P<hid>\d+|[A-Z]{8})',serve_hit,name='serve_hit'),
+    url(r'^accept/(?P<hid>\d+|[A-Z]{8})',serve_hit,name='serve_hit'),
+    url(r'^turk/(?P<hid>\d+|[A-Z]{8})',preview_hit,name='preview_hit'),
     url(r'^turk/preview',not_consent_view,name='not_consent_view'),
     url(r'^turk/end/(?P<rid>\d+|[A-Z]{8})',end_assignment,name='end_assignment'),
     url(r'^sync/(?P<rid>\d+|[A-Z]{8})/$',sync,name='sync_data'),

--- a/expdj/apps/turk/urls.py
+++ b/expdj/apps/turk/urls.py
@@ -1,5 +1,5 @@
 from expdj.apps.turk.views import edit_hit, delete_hit, expire_hit, serve_hit, \
- multiple_new_hit, sync, end_assignment, finished_view
+ multiple_new_hit, sync, end_assignment, finished_view, not_consent_view
 from django.views.generic.base import TemplateView
 from django.conf.urls import patterns, url
 
@@ -13,6 +13,7 @@ urlpatterns = patterns('',
 
     # Turk Deployments
     url(r'^turk/(?P<hid>\d+|[A-Z]{8})',serve_hit,name='serve_hit'),
+    url(r'^turk/preview',not_consent_view,name='not_consent_view'),
     url(r'^turk/end/(?P<rid>\d+|[A-Z]{8})',end_assignment,name='end_assignment'),
     url(r'^sync/(?P<rid>\d+|[A-Z]{8})/$',sync,name='sync_data'),
     url(r'^sync/$',sync,name='sync_data'),

--- a/expdj/apps/turk/views.py
+++ b/expdj/apps/turk/views.py
@@ -1,4 +1,5 @@
-from expdj.apps.experiments.views import check_battery_edit_permission, check_mturk_access, deploy_battery
+from expdj.apps.experiments.views import check_battery_edit_permission, check_mturk_access, \
+get_battery_intro, deploy_battery
 from expdj.apps.turk.utils import get_connection, get_worker_url, get_host, get_worker_experiments, \
 select_random_n
 from django.http.response import HttpResponseRedirect, HttpResponseForbidden, HttpResponse, Http404
@@ -32,17 +33,6 @@ def get_hit(hid,request,mode=None):
         return hit
 
 #### VIEWS ############################################################
-
-def get_battery_intro(battery,show_advertisement=True):
-
-    instruction_forms = []
-
-    # !Important: title for consent instructions must be "Consent" - see instructions_modal.html if you change
-    if show_advertisement == True:
-        if battery.advertisement != None: instruction_forms.append({"title":"Advertisement","html":battery.advertisement})
-    if battery.consent != None: instruction_forms.append({"title":"Consent","html":battery.consent})
-    if battery.instructions != None: instruction_forms.append({"title":"Instructions","html":battery.instructions})
-    return instruction_forms
 
 def get_amazon_variables(request):
     '''get_amazon_variables gets the "GET" variables from the URL,
@@ -159,6 +149,11 @@ def preview_hit(request,hid):
         context = get_amazon_variables(request)
         context["instruction_forms"] = get_battery_intro(battery)
         context["hit_uid"] = hid
+        context["start_url"] = "/accept/%s/?assignmentId=%s&workerId=%s&turkSubmitTo=%s&hitId=%s" %(hid,
+                                                                                                    context["assignment_id"],
+                                                                                                    context["worker_id"],
+                                                                                                    context["turk_submit_to"],
+                                                                                                    context["hit_id"])
 
         response = render_to_response("turk/serve_battery_intro.html", context)
 
@@ -352,3 +347,4 @@ def sync(request,rid=None):
     else:
         data = json.dumps({"message":"received!"})
     return HttpResponse(data, content_type='application/json')
+

--- a/expdj/apps/turk/views.py
+++ b/expdj/apps/turk/views.py
@@ -46,7 +46,7 @@ def get_battery_intro(battery,show_advertisement=True):
 
 
 def run_hit(request,hit_id,worker_id,aid):
-    '''run_hit runs the experiment for a hit
+    '''run_hit runs the experiment for a hit, after the instructions, consent, and ad
     :param hid: the hit id
     :param wid: the worker id
     :param aid: the assignment id
@@ -61,9 +61,9 @@ def run_hit(request,hit_id,worker_id,aid):
 
     if request.user_agent.is_bot:
         return render_to_response("turk/robot_sorry.html")
-    
+
     if request.user_agent.is_pc:
- 
+
         # Get Experiment Factory objects for each
         worker = get_worker(worker_id)
 
@@ -150,6 +150,7 @@ def serve_hit(request,hid):
                    "assignment_id": assignment_id,
                    "amazon_host": host,
                    "hit_id": hit_id,
+                   "hit_uid":hid,
                    "turk_submit_to":turk_submit_to,
                    "instruction_forms":instruction_forms}
 


### PR DESCRIPTION
This PR will significantly change the deployment infrastructure so that instructions, consent, and advertisement are decoupled from the experiments themselves. This means an overhaul of local deployment, local preview (now called a dummy run), anonymous local deployment, mechanical turk preview, and mechanical turk actual run. Overall, regardless of the deployment, the user goes through the following:

      instructions --> click Start Experiment --> [open new window] --> experiment content

Specifically:

- [new functions](https://github.com/expfactory/expfactory-docker/compare/master...vsoch:master?expand=1#diff-4fb8f33ccdeb36e730c80a7be9efd4b2R273) for experiment deployment for intro, dummy (local preview), and instruction viewing.
- equivalent to the above, new functions for [previewing](https://github.com/expfactory/expfactory-docker/compare/master...vsoch:master?expand=1#diff-a9e8b695b3cd9abff4e7b1200286a2c8R138) and [serving](https://github.com/expfactory/expfactory-docker/compare/master...vsoch:master?expand=1#diff-a9e8b695b3cd9abff4e7b1200286a2c8R59) Hits. You'll notice the old `serve_hit`, which used to include instructions etc in one go, has been torn up and refactored.
- to make this possible, expfactory-python needed changes to the [jspsych_init function](https://github.com/expfactory/expfactory-python/commit/41b4bf6d09a36afe147b0b5b6d37cfe6111e5629)
- [deploy battery](https://github.com/expfactory/expfactory-docker/compare/master...vsoch:master?expand=1#diff-4fb8f33ccdeb36e730c80a7be9efd4b2R387) function, which used to parse the instructions, now only deploys the experiment (after being sent from the instructions view).
- the [old mturk preview](https://github.com/expfactory/expfactory-docker/compare/master...vsoch:master?expand=1#diff-95f1edb4c9c74054db9eff49868510d2R13) that used to include just instructions and then a message to participate in the experiment to see content, now serves as a second static page that is redirected to in the case the turker has not yet accepted the assignment. This is also opened in a new window.
- all views now use a [common instructions/intro view](https://github.com/vsoch/expfactory-docker/blob/efd3e5e39cf4e5a3fb7c585d80abbf672711f04a/expdj/apps/turk/templates/turk/serve_battery_intro.html). This is a new template that only serves to show the advertisement, instructions, and consent. It takes the a `start_url` variable that will open the page (IN A NEW WINDOW) to proceed to the experiment, whether that is local or on mechanical turk. 
- I have separated the functions to [obtain the instructions](https://github.com/expfactory/expfactory-docker/compare/master...vsoch:master?expand=1#diff-4fb8f33ccdeb36e730c80a7be9efd4b2R248), along with to [get aws variables from the url](https://github.com/expfactory/expfactory-docker/compare/master...vsoch:master?expand=1#diff-a9e8b695b3cd9abff4e7b1200286a2c8R37) etc to make the application a bit cleaner.
- Mechanical turk deployment, local deployment, anon and preview function urls are completely different. The old urls "serve" or "hit/"  now will lead to previews, and a new url "accept" goes to the battery. See here for [local](https://github.com/vsoch/expfactory-docker/blob/efd3e5e39cf4e5a3fb7c585d80abbf672711f04a/expdj/apps/experiments/urls.py#L50)|[turk](https://github.com/expfactory/expfactory-docker/compare/master...vsoch:master?expand=1#diff-ea96eab112146ad56f25f1aea65e3cc4R15)
- The preview battery button was previously using the first HIT URL, and now is it's own (new) function, and the urls in the battery_details page have been changed.

