### PR TITLE
Issue56

### DIFF
--- a/expdj/apps/experiments/forms.py
+++ b/expdj/apps/experiments/forms.py
@@ -57,8 +57,8 @@ class ExperimentForm(ModelForm):
 class BatteryForm(ModelForm):
 
     class Meta:
-        exclude = ('owner','contributors','experiments','bonus_active'
-                   'blacklist_active','blacklist_threshold')
+        exclude = ('owner', 'contributors', 'experiments',' bonus_active'
+                   'blacklist_active', 'blacklist_threshold')
         model = Battery
 
     def clean(self):

--- a/expdj/apps/experiments/models.py
+++ b/expdj/apps/experiments/models.py
@@ -1,14 +1,21 @@
-from guardian.shortcuts import assign_perm, get_users_with_perms, remove_perm
-from django.core.validators import MaxValueValidator, MinValueValidator
-from django.db.models.signals import m2m_changed
-from polymorphic.models import PolymorphicModel
-from django.core.urlresolvers import reverse
-from django.contrib.auth.models import User
-from django.db.models import Q, DO_NOTHING
-from jsonfield import JSONField
-from django.db import models
 import collections
 import operator
+
+from guardian.shortcuts import assign_perm, get_users_with_perms, remove_perm
+from jsonfield import JSONField
+from polymorphic.models import PolymorphicModel
+
+from django.contrib.auth.models import User
+from django.core.exceptions import ObjectDoesNotExist
+from django.core.urlresolvers import reverse
+from django.core.validators import MaxValueValidator, MinValueValidator
+from django.db import models
+from django.db.models import Q, DO_NOTHING
+from django.db.models.signals import m2m_changed
+
+#  trying to import Result object directly from models was giving an import 
+#  error here, even though the import matched views.py exactly.
+from expdj.apps import turk
 
 class CognitiveAtlasConcept(models.Model):
     name = models.CharField(max_length=1000, null=False, blank=False)
@@ -133,6 +140,12 @@ class Experiment(models.Model):
 
 class Battery(models.Model):
     '''A battery is a collection of experiment templates'''
+
+    ORDER_CHOICES = (
+        ("random", "random"),
+        ("specified", "specified"),
+    )
+
     # Name must be unique because anonymous link is generated from hash
     name = models.CharField(max_length=200, unique = True, null=False, verbose_name="Name of battery")
     description = models.TextField(blank=True, null=True)
@@ -150,19 +163,32 @@ class Battery(models.Model):
     active = models.BooleanField(choices=((False, 'Inactive'),
                                           (True, 'Active')),
                                            default=True,verbose_name="Active")
-    ORDER_CHOICES = (
-        ("random", "random"),
-        ("specified", "specified"),
-    )
-
     presentation_order = models.CharField("order function for presentation of experiments",max_length=200,choices=ORDER_CHOICES,default="random",help_text="Select experiments randomly, or in a custom specified order.")
-    blacklist_active = models.BooleanField(choices=((False, 'Off'),
-                                                    (True, 'On')),
-                                                    default=False,verbose_name="Blacklist based on rejection criteria")
+    blacklist_active = models.BooleanField(
+        choices=((False, 'Off'), (True, 'On')),
+        default=False,
+        verbose_name="Blacklist based on rejection criteria"
+    )
     blacklist_threshold = models.PositiveIntegerField(null=True,blank=True,default=10,help_text="Number of experiments to fail reject condition to add participant to blacklist",validators = [MinValueValidator(0.0)])
-    bonus_active = models.BooleanField(choices=((False, 'Off'),
-                                                (True, 'On')),
-                                                default=False,verbose_name="Bonus based on reward criteria")
+    bonus_active = models.BooleanField(
+        choices=((False, 'Off'), (True, 'On')),
+        default=False,
+        verbose_name="Bonus based on reward criteria"
+    )
+    required_batteries = models.ManyToManyField(
+        "Battery",
+        blank=True,
+        related_name='required_batteries_mtm',
+        help_text=("Batteries which must be completed for this battery to be "
+                  "attempted")
+    )
+    restricted_batteries = models.ManyToManyField(
+        "Battery",
+        blank=True,
+        related_name='restricted_batteries_mtm',
+        help_text=("Batteries that must not be completed in order for "
+                   "this battery to be attempted")
+    )
 
     def get_absolute_url(self):
         return_cid = self.id

--- a/expdj/apps/experiments/templates/experiments/edit_battery.html
+++ b/expdj/apps/experiments/templates/experiments/edit_battery.html
@@ -1,6 +1,8 @@
 {% extends "main/base.html" %}
+{% load static %}
 {% load crispy_forms_tags %}
 {% block head %}
+<link rel="stylesheet" href="{% static "css/select2.min.css" %}" />
 {% endblock %}
 {% block content %}
 
@@ -21,4 +23,11 @@
         </article>
     </div>
 </div>
+{% endblock %}
+{% block scripts %}
+<script src="{% static "js/select2.min.js"%}" type="text/javascript"></script>
+<script>
+    $("#id_required_batteries").select2();
+    $("#id_restricted_batteries").select2();
+</script>
 {% endblock %}

--- a/expdj/apps/experiments/views.py
+++ b/expdj/apps/experiments/views.py
@@ -502,8 +502,9 @@ def deploy_battery(deployment, battery, experiment_type, context, task_list,
             runcode = runcode.replace("{{result.id}}",str(result.id))
         runcode = runcode.replace("{{next_page}}",next_page)
         if experiments_left:
-            expleft_msg = "</p><p>Experiments left in battery: {0:d}</p>"
-            expleft_msg = expleft_msg.format(experiments_left)
+            total_experiments = battery.number_of_experiments
+            expleft_msg = "</p><p>Experiments left in battery {0:d} out of {1:d}</p>"
+            expleft_msg = expleft_msg.format(experiments_left, total_experiments)
             runcode = runcode.replace("</p>", expleft_msg)
     elif experiment_type in ["games"]:
         experiment = load_experiment(experiment_folders[0])

--- a/expdj/apps/experiments/views.py
+++ b/expdj/apps/experiments/views.py
@@ -409,7 +409,7 @@ def serve_battery(request,bid,userid=None):
     missing_batteries, blocking_batteries = check_battery_dependencies(battery, userid)
     if missing_batteries or blocking_batteries:
         return render_to_response(
-            "experiments/battery_requirements_not_met.html",
+            "turk/battery_requirements_not_met.html",
             context={'missing_batteries': missing_batteries,
                      'blocking_batteries': blocking_batteries}
         )

--- a/expdj/apps/experiments/views.py
+++ b/expdj/apps/experiments/views.py
@@ -474,6 +474,7 @@ def deploy_battery(deployment, battery, experiment_type, context, task_list,
     :param template: html template to render
     :param result: the result object, turk.models.Result
     :param last_experiment: boolean if true will redirect the user to a page to submit the result (for surveys)
+    :param experiments_left: integer indicating how many experiments are left in battery.
     '''
     if next_page == None:
         next_page = "javascript:window.location.reload();"

--- a/expdj/apps/turk/templates/turk/battery_requirements_not_met.html
+++ b/expdj/apps/turk/templates/turk/battery_requirements_not_met.html
@@ -1,0 +1,49 @@
+{% load staticfiles %}
+<html>
+<head>
+    <title>The Experiment Factory: Thank you</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link href='https://fonts.googleapis.com/css?family=Roboto' rel='stylesheet' type='text/css'>
+</head>
+<body>
+<style>
+div {
+    width: 400px;
+    height: 400px;
+    font-family: 'Roboto', sans-serif;
+    position: absolute;
+    top:0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+
+    margin: auto;
+}
+</style>
+<body>
+    <div>
+        <h3>Some Requirements Have Not Been Met.</h3>
+        {% if missing_batteries %}
+            The following batteries need to be completed before the current one may be attempted: <br>
+            <ul>
+            {% for battery in missing_batteries %}
+                <li>
+                    {{ battery.name }}
+                </li>
+            {% endfor %}
+            </ul>
+        {% endif %} 
+        {% if blocking_batteries %}
+            The following batteries conflict with the current battery. Their completion is preventing the current battery from being attempted: <br>
+            <ul>
+            {% for battery in blocking_batteries %}
+                <li>
+                    {{ battery.name }}
+                </li>
+            {% endfor %}
+            </ul>
+        {% endif %} 
+    </div>
+</body>
+</html>

--- a/expdj/apps/turk/utils.py
+++ b/expdj/apps/turk/utils.py
@@ -122,7 +122,8 @@ def get_worker_experiments(worker,battery,completed=False):
         experiment_selection = [e for e in battery_tags if e not in worker_tags]
     else:
         experiment_selection = [e for e in worker_tags if e in battery_tags]
-    return Experiment.objects.filter(template__exp_id__in=experiment_selection)
+    return Experiment.objects.filter(template__exp_id__in=experiment_selection,
+                                     battery_experiments__id=battery.id)
 
 
 def get_time_difference(d1,d2,format='%Y-%m-%d %H:%M:%S'):

--- a/expdj/apps/turk/utils.py
+++ b/expdj/apps/turk/utils.py
@@ -75,7 +75,7 @@ def is_sandbox():
 def get_worker_url():
     """Get proper URL depending upon sandbox settings"""
 
-    if is_sandbox():
+    if settings.MTURK_ALLOW == False:
         return SANDBOX_WORKER_URL
     else:
         return PRODUCTION_WORKER_URL

--- a/expdj/apps/turk/views.py
+++ b/expdj/apps/turk/views.py
@@ -1,25 +1,30 @@
-from expdj.apps.experiments.views import check_battery_edit_permission, check_mturk_access, \
-get_battery_intro, deploy_battery
-from expdj.apps.turk.utils import get_connection, get_worker_url, get_host, get_worker_experiments
-from django.http.response import HttpResponseRedirect, HttpResponseForbidden, HttpResponse, Http404
-from django.shortcuts import get_object_or_404, render_to_response, render, redirect
-from expdj.apps.turk.tasks import assign_experiment_credit, get_unique_experiments
-from expdj.apps.experiments.utils import get_experiment_type, select_experiments
-from expdj.apps.turk.models import Worker, HIT, Assignment, Result, get_worker
-from expdj.apps.experiments.models import Battery, ExperimentTemplate
-from expfactory.battery import get_load_static, get_experiment_run
-from expdj.settings import BASE_DIR,STATIC_ROOT,MEDIA_ROOT
-from django.contrib.auth.decorators import login_required
-from django.core.management.base import BaseCommand
-from django.views.decorators.csrf import ensure_csrf_cookie
-from expdj.apps.turk.forms import HITForm
 from datetime import timedelta, datetime
-from django.utils import timezone
-from optparse import make_option
-from numpy.random import choice
-import requests
 import json
 import os
+import requests
+
+from expfactory.battery import get_load_static, get_experiment_run
+from numpy.random import choice
+from optparse import make_option
+
+from django.contrib.auth.decorators import login_required
+from django.core.management.base import BaseCommand
+from django.http.response import HttpResponseRedirect, HttpResponseForbidden, HttpResponse, Http404
+from django.shortcuts import get_object_or_404, render_to_response, render, redirect
+from django.utils import timezone
+from django.views.decorators.csrf import ensure_csrf_cookie
+
+from expdj.apps.experiments.models import Battery, ExperimentTemplate
+from expdj.apps.experiments.views import check_battery_edit_permission, check_mturk_access, \
+get_battery_intro, deploy_battery
+from expdj.apps.experiments.utils import get_experiment_type, select_experiments
+from expdj.apps.turk.forms import HITForm
+from expdj.apps.turk.models import Worker, HIT, Assignment, Result, get_worker
+from expdj.apps.turk.tasks import (assign_experiment_credit,
+    check_battery_dependencies, get_unique_experiments)
+from expdj.apps.turk.utils import (get_connection, get_host, get_worker_url,
+    get_worker_experiments)
+from expdj.settings import BASE_DIR,STATIC_ROOT,MEDIA_ROOT
 
 media_dir = os.path.join(BASE_DIR,MEDIA_ROOT)
 
@@ -127,6 +132,10 @@ def serve_hit(request,hid):
         # Get Experiment Factory objects for each
         worker = get_worker(aws["worker_id"])
 
+        check_battery_response = check_battery_view(battery, aws["worker_id"])
+        if (check_battery_response):
+            return check_battery_response
+
         # This is the submit URL, either external or sandbox
         host = get_host(hit)
 
@@ -208,6 +217,7 @@ def preview_hit(request,hid):
         hit =  get_hit(hid,request)
         battery = hit.battery
         context = get_amazon_variables(request)
+
         context["instruction_forms"] = get_battery_intro(battery)
         context["hit_uid"] = hid
         context["start_url"] = "/accept/%s/?assignmentId=%s&workerId=%s&turkSubmitTo=%s&hitId=%s" %(hid,
@@ -378,3 +388,14 @@ def get_flagged_questions(number=None):
     if number == None:
         return questions
     return choice(questions,int(number))
+
+def check_battery_view(battery, worker_id):
+    missing_batteries, blocking_batteries = check_battery_dependencies(battery, worker_id)
+    if missing_batteries or blocking_batteries:
+        return render_to_response(
+            "turk/battery_requirements_not_met.html",
+            context={'missing_batteries': missing_batteries,
+                     'blocking_batteries': blocking_batteries}
+        )
+    else:
+        return None

--- a/expdj/apps/turk/views.py
+++ b/expdj/apps/turk/views.py
@@ -161,13 +161,14 @@ def serve_hit(request,hid):
 
         # Does the worker have experiments remaining for the hit?
         uncompleted_experiments = get_worker_experiments(worker,hit.battery)
-        if len(uncompleted_experiments) == 0:
+        experiments_left = len(uncompleted_experiments)  
+        if experiments_left == 0:
             # Thank you for your participation - no more experiments!
             return render_to_response("turk/worker_sorry.html")
 
         # if it's the last experiment, we will submit the result to amazon (only for surveys)
         last_experiment = False
-        if len(uncompleted_experiments) == 1:
+        if experiments_left == 1:
             last_experiment = True
 
         task_list = select_experiments(battery,uncompleted_experiments)
@@ -189,18 +190,21 @@ def serve_hit(request,hid):
         aws["uniqueId"] = result.id
 
         # If this is the last experiment, the finish button will link to a thank you page.
-        if len(uncompleted_experiments) == 1:
+        if experiments_left == 1:
             next_page = "/finished"
 
-        return deploy_battery(deployment="docker-mturk",
-                              battery=battery,
-                              experiment_type=experiment_type,
-                              context=aws,
-                              task_list=task_list,
-                              template=template,
-                              next_page=None,
-                              result=result,
-                              last_experiment=last_experiment)
+        return deploy_battery(
+            deployment="docker-mturk",
+            battery=battery,
+            experiment_type=experiment_type,
+            context=aws,
+            task_list=task_list,
+            template=template,
+            next_page=None,
+            result=result,
+            last_experiment=last_experiment,
+            experiments_left=experiments_left-1
+        )
 
     else:
         return render_to_response("turk/error_sorry.html")


### PR DESCRIPTION
Addresses #56 
Added a new optional argument to deploy_battery that has the number of experiments left. If the argument is provided then a message is inserted into the runcode variable with that value to let the worker know how many experiments are left in the battery.

The length of the uncompleted_experiments seems to be off by 1, so when deploy battery is being called the experiments_left variable is being reduced by 1.

The replacement happening to run code is assuming that there is a set of paragraph tags that can be replaced on to insert the message. This is a potential point of failure if we expect the html generated in  get_jspsych_init to change in the future. On the other hand it didn't require modifying the expfactory-python code with another template-esque variable like how {{ next }} is currently being replaced on.