### PR TITLE
Switched back to using old serializers.

### DIFF
--- a/expdj/apps/turk/api_views.py
+++ b/expdj/apps/turk/api_views.py
@@ -9,4 +9,4 @@ class BatteryResultAPIList(generics.ListAPIView):
     serializer_class = WorkerResultsSerializer
     def get_queryset(self):
         battery_id = self.kwargs.get('bid')
-        return Worker.objects.filter(result_worker__battery__id=battery_id)
+        return Worker.objects.filter(result_worker__battery__id=battery_id).distinct()

--- a/expdj/apps/turk/api_views.py
+++ b/expdj/apps/turk/api_views.py
@@ -3,10 +3,10 @@ from rest_framework import permissions
 from rest_framework import viewsets
 
 from expdj.apps.turk.models import Result, Worker
-from expdj.apps.turk.serializers import WorkerResultsSerializer
+from expdj.apps.turk.serializers import ResultSerializer
 
 class BatteryResultAPIList(generics.ListAPIView):
-    serializer_class = WorkerResultsSerializer
+    serializer_class = ResultSerializer
     def get_queryset(self):
         battery_id = self.kwargs.get('bid')
-        return Worker.objects.filter(result_worker__battery__id=battery_id).distinct()
+        return Result.objects.filter(battery__id=battery_id)

--- a/expdj/apps/turk/serializers.py
+++ b/expdj/apps/turk/serializers.py
@@ -3,22 +3,43 @@ from rest_framework import serializers
 from expdj.apps.experiments.serializers import (
     BatteryDescriptionSerializer, ExperimentTemplateSerializer
 )
+from expdj.apps.experiments.models import Battery, ExperimentTemplate, CognitiveAtlasTask
 from expdj.apps.turk.models import Result, Worker
 from expdj.apps.turk.utils import to_dict
 
+class BatterySerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = Battery
+        fields = ('name', 'description')
+
+class CognitiveAtlasTaskSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = CognitiveAtlasTask
+        fields = ('name','cog_atlas_id')
+
+class ExperimentTemplateSerializer(serializers.HyperlinkedModelSerializer):
+    cognitive_atlas_task = CognitiveAtlasTaskSerializer()
+    class Meta:
+        model = ExperimentTemplate
+        fields = ('exp_id','name','cognitive_atlas_task','reference','version','template')
+
+class WorkerSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = Worker
+        fields = ["id"]
+
 class ResultSerializer(serializers.HyperlinkedModelSerializer):
     experiment = ExperimentTemplateSerializer()
+    battery = BatterySerializer()
+    worker = WorkerSerializer()
     data = serializers.SerializerMethodField('get_taskdata')
 
-    def get_taskdata(self, result):
+    def get_taskdata(self,result):
         return to_dict(result.taskdata)
 
     class Meta:
         model = Result
-        fields = [
-            'data', 'experiment', 'language', 'browser',
-            'platform', 'completed', 'finishtime'
-        ]
+        fields = ('data','experiment','battery','worker','language','browser','platform','completed','finishtime')
 
 class WorkerResultsSerializer(serializers.HyperlinkedModelSerializer):
     results = ResultSerializer(many=True, read_only=True, source='result_worker')


### PR DESCRIPTION
organizing results by worker ran out of memory if there were large amounts of results. 

Will need to remove duplicate code at some point.