### PR TITLE
[WIP] Boto upgrade

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+expdj/experiment_repo

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ compose/nginx/ssl*
 *.cred
 
 /expdj/experiment_repo/*
+postgres-data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ RUN apt-get update && apt-get install -y \
     libhdf5-dev \
     libgeos-dev \
     openssl \
-    wget
+    wget\
+    git
 
 RUN mkdir /code
 WORKDIR /code

--- a/expdj/apps/experiments/static/js/jquery_boostrap_modal_steps.js
+++ b/expdj/apps/experiments/static/js/jquery_boostrap_modal_steps.js
@@ -8,7 +8,7 @@
             btnCancelHtml: 'Cancel',
             btnPreviousHtml: 'Previous',
             btnNextHtml: 'Next',
-            btnLastStepHtml: 'Start Experiment',
+            btnLastStepHtml: 'Next',
             disableNextButton: false,
             completeCallback: function(){
               $("#start_experiment_button").click();

--- a/expdj/apps/experiments/views.py
+++ b/expdj/apps/experiments/views.py
@@ -322,11 +322,11 @@ def get_battery_intro(battery, show_advertisement=True):
         if battery.advertisement is not None:
             instruction_forms.append(
                 {"title": "Advertisement", "html": battery.advertisement})
-    if battery.consent is not None:
-        instruction_forms.append({"title": "Consent", "html": battery.consent})
     if battery.instructions is not None:
         instruction_forms.append(
             {"title": "Instructions", "html": battery.instructions})
+    if battery.consent is not None:
+        instruction_forms.append({"title": "Consent", "html": battery.consent})
     return instruction_forms
 
 

--- a/expdj/apps/turk/api_views.py
+++ b/expdj/apps/turk/api_views.py
@@ -17,7 +17,7 @@ class BatteryResultAPIList(generics.ListAPIView):
 
     def get_queryset(self):
         battery_id = self.kwargs.get('bid')
-        if (Battery.objects.get(pk=battery_id).owner is not self.request.user.pk):
+        if (Battery.objects.get(pk=battery_id).owner.id is not self.request.user.pk):
             raise exceptions.PermissionDenied()
         return Result.objects.filter(battery__id=battery_id)
 

--- a/expdj/apps/turk/api_views.py
+++ b/expdj/apps/turk/api_views.py
@@ -41,7 +41,7 @@ class WorkerExperiments(APIView):
         if len(exps) ==  0 and not marked_complete:
             all_assignments.filter(completed=False).update(completed=True)
             submit = True
-            updated_assign_experiment_credit.apply_async([worker_id, hit.battery_id], countdown=60)
+            updated_assign_experiment_credit.apply_async([worker_id, hit.battery_id, hit_id], countdown=60)
         elif len(exps) == 0 and marked_complete:
             status = 'Submit Attempted'
 

--- a/expdj/apps/turk/models.py
+++ b/expdj/apps/turk/models.py
@@ -394,7 +394,7 @@ class HIT(models.Model):
         if self.qualification_custom not in [None, ""]:
             qualifications.append({
                 "QualificationTypeId": self.qualification_custom,
-                "Comparator": self.qualification_cursom_operator,
+                "Comparator": self.qualification_custom_operator,
                 "IntegerValues": [self.qualification_custom_value],
                 "ActionsGuarded": "DiscoverPreviewAndAccept"
             })
@@ -438,10 +438,11 @@ class HIT(models.Model):
                 'Minimal',
                 'HITDetail')
         '''
+        print(qualifications)
         if len(qualifications) > 1:
-            settings['QualificationRequirements'] = qualifications,
+            settings['QualificationRequirements'] = qualifications
         elif len(qualifications) == 1:
-            settings['QualificationRequirements'] = qualifications[0],
+            settings['QualificationRequirements'] = qualifications[0]
 
         result = self.connection.create_hit(**settings)['HIT']
 

--- a/expdj/apps/turk/models.py
+++ b/expdj/apps/turk/models.py
@@ -346,7 +346,7 @@ class HIT(models.Model):
 
     ''' Does not appear to be in use currently
     def extend(self, assignments_increment=None, expiration_increment=None):
-        """Increase the maximum assignments or extend the expiration date"""
+        # Increase the maximum assignments or extend the expiration date
         if not self.has_connection():
             self.generate_connection()
         self.connection.update_expiration_for_hit(
@@ -396,7 +396,7 @@ class HIT(models.Model):
                 "QualificationTypeId": self.qualification_custom,
                 "Comparator": self.qualification_custom_operator,
                 "IntegerValues": [self.qualification_custom_value],
-                "ActionsGuarded": "DiscoverPreviewAndAccept"
+                "ActionsGuarded": "Accept"
             })
         if self.qualification_locale != 'None':
             qualifications.append({
@@ -438,11 +438,7 @@ class HIT(models.Model):
                 'Minimal',
                 'HITDetail')
         '''
-        print(qualifications)
-        if len(qualifications) > 1:
-            settings['QualificationRequirements'] = qualifications
-        elif len(qualifications) == 1:
-            settings['QualificationRequirements'] = qualifications[0]
+        settings['QualificationRequirements'] = qualifications
 
         result = self.connection.create_hit(**settings)['HIT']
 
@@ -661,7 +657,7 @@ class Assignment(models.Model):
 
         if assignment is not None:
             self.status = self.reverse_status_lookup[assignment['AssignmentStatus']]
-            self.worker_id = get_worker(assignment.WorkerId)
+            self.worker = get_worker(assignment['WorkerId'])
             self.submit_time = assignment['SubmitTime']
             self.accept_time = assignment['AcceptTime']
             self.auto_approval_time = assignment['AutoApprovalTime']

--- a/expdj/apps/turk/tasks.py
+++ b/expdj/apps/turk/tasks.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 import os
 
 import numpy
-from boto.mturk.price import Price
 from celery import Celery, shared_task
 from django.conf import settings
 from django.utils import timezone
@@ -15,6 +14,7 @@ from expdj.apps.experiments.models import Battery, ExperimentTemplate
 from expdj.apps.experiments.utils import get_experiment_type
 from expdj.apps.turk.models import (HIT, Assignment, Blacklist, Bonus, Result,
                                     get_worker)
+from expdj.apps.turk.utils import get_worker_experiments, get_connection, get_credentials
 from expdj.settings import TURK
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'expdj.settings')
@@ -59,6 +59,45 @@ def assign_experiment_credit(worker_id):
                 result.assignment.save()
                 grant_bonus(result.id)
 
+@shared_task
+def updated_assign_experiment_credit(worker_id, battery_id):
+    ''' We want to approve an asignment for a given worker/battery if:
+        1) No assignment is marked as complete
+        2) And no assignment at the AWS API is marked as approved
+        3) And there is at least one assignment at the AWS API that is approved
+    '''
+    battery = Battery.objects.get(id=battery_id)
+    all_assignments = Assignment.objects.filter(worker_id=worker_id, hit__battery_id=battery_id)
+    AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY_ID = get_credentials(battery)
+    conn = get_connection(AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY_ID)
+    submitted = []
+    approved = False
+    for assignment in all_assignments:
+        try:
+            aws_assignment = conn.get_assignment(AssignmentId=assignment.mturk_id)['Assignment']
+            if aws_assignment['AssignmentStatus'] == 'Submitted':
+                submitted.append(assignment)
+            if aws_assignment['AssignmentStatus'] == 'Approved':
+                approved = True
+                continue
+        except Exception as e:
+            print(e)
+            continue
+        
+    if len(submitted) == 0:
+        return
+
+    if not approved:
+        submitted[0].approve()
+        submitted[0].completed = True
+        submitted[0].save()
+        submitted = submitted[1:]
+
+    for x in submitted:
+        response = conn.reject_assignment(
+            AssignmentId=x.mturk_id,
+            RequesterFeedback='Already attempted to approve another HIT for the same set of experiments'
+        )
 
 @shared_task
 def check_blacklist(result_id):
@@ -173,10 +212,9 @@ def grant_bonus(result_id):
     try:
         bonus = Bonus.objects.get(worker=worker, battery=battery)
         amount = bonus.calculate_bonus()
-        price = Price(amount)
         reason = get_bonus_reason(bonus)
         result.assignment.hit.connection.grant_bonus(
-            worker.id, result.assignment.mturk_id, price, reason)
+            worker.id, result.assignment.mturk_id, amount, reason)
         bonus.granted = True
         bonus.save()
     except Bonus.DoesNotExist:

--- a/expdj/apps/turk/templates/experiments/mturk_battery.html
+++ b/expdj/apps/turk/templates/experiments/mturk_battery.html
@@ -18,7 +18,7 @@
 
 {% include "experiments/serve_battery_runjs.html" %}
 
-{% if amazon_host == "mechanicalturk.amazonaws.com" %}
+{% if amazon_host == "mturk-requester.us-east-1.amazonaws.com" %}
 <form action="https://www.mturk.com/mturk/externalSubmit" method="POST" id="turkey_form">
 {% else %}
 <form action="https://workersandbox.mturk.com/mturk/externalSubmit" method="POST" id="turkey_form">

--- a/expdj/apps/turk/templates/games/mturk_battery.html
+++ b/expdj/apps/turk/templates/games/mturk_battery.html
@@ -28,7 +28,7 @@ $(document).ready(function(){
 });
 </script>
 
-{% if amazon_host == "mechanicalturk.amazonaws.com" %}
+{% if amazon_host == "mturk-requester.us-east-1.amazonaws.com" %}
 <form action="https://www.mturk.com/mturk/externalSubmit" method="POST" id="turkey_form">
 {% else %}
 <form action="https://workersandbox.mturk.com/mturk/externalSubmit" method="POST" id="turkey_form">

--- a/expdj/apps/turk/templates/surveys/worker_finished.html
+++ b/expdj/apps/turk/templates/surveys/worker_finished.html
@@ -32,7 +32,7 @@ div {
 </html>
 
 
-{% if amazon_host == "mechanicalturk.amazonaws.com" %}
+{% if amazon_host == "mturk-requester.us-east-1.amazonaws.com" %}
 <form action="https://www.mturk.com/mturk/externalSubmit" method="POST" id="turkey_form">
 {% else %}
 <form action="https://workersandbox.mturk.com/mturk/externalSubmit" method="POST" id="turkey_form">

--- a/expdj/apps/turk/templates/turk/serve_battery_intro.html
+++ b/expdj/apps/turk/templates/turk/serve_battery_intro.html
@@ -22,8 +22,7 @@ $(document).ready(function(){
     var complete = "1";
     $("#next_button").click(function() {
 
-        if (complete == "3"){
-
+        if (complete == "3" || complete == "complete"){
             {% if assignment_id %}
                 window.open("{{ start_url }}")
                 // window.location.assign("{{ start_url }}")

--- a/expdj/apps/turk/templates/turk/serve_battery_intro.html
+++ b/expdj/apps/turk/templates/turk/serve_battery_intro.html
@@ -22,13 +22,17 @@ $(document).ready(function(){
     var complete = "1";
     $("#next_button").click(function() {
 
-        if (complete == "complete"){
+        if (complete == "3"){
 
             {% if assignment_id %}
                 window.open("{{ start_url }}")
+                // window.location.assign("{{ start_url }}")
             {% else %}
                 window.open("{% url 'not_consent_view' %}",fullscreen=1)
+                // window.location.assign("{% url 'not_consent_view' %}")
             {% endif %}
+            $("#next_button").addClass("hidden")
+            $("#previous_button").addClass("hidden")
         }
         complete = $("#next_button").attr("data-step")
     });

--- a/expdj/apps/turk/templates/turk/status_monitor.html
+++ b/expdj/apps/turk/templates/turk/status_monitor.html
@@ -1,0 +1,36 @@
+<div>
+    Experiments left in battery: <div id="remain_exp"></div><br/>
+    Current assignment status: <div id="assignment_status"></div><br/>
+
+    {% if amazon_host == "mechanicalturk.amazonaws.com" %}
+    <form action="https://www.mturk.com/mturk/externalSubmit" method="POST" id="external_submit_form">
+    {% else %}
+    <form action="https://workersandbox.mturk.com/mturk/externalSubmit" method="POST" id="external_submit_form">
+    {% endif %}
+            <input type="hidden" id="assignmentId" value="{{ assignment_id }}" name="assignmentId"/>
+            <input type="hidden" id="workerId" value="{{ worker_id }}" name="workerId"/>
+            <input type="hidden" id="hitId" value="{{ hit_id }}" name="hitId"/>
+    </form>
+
+    <script>
+        (function poll() {
+            setTimeout(function() {
+                $.ajax({
+                    url: "{{ status_url }}",
+                    type: "GET",
+                    success: function(data) {
+                        console.log(data);
+                        $("#remain_exp").text(data.experiments.length);
+                        $("#assignment_status").text(data.assignment_status);
+                        if ((data.experiments.length === 0) && (data.assignment_status == "Not Submitted") && data.submit) {
+                            $("#external_submit_form").submit(); 
+                        }
+                    },
+                    dataType: "json",
+                    complete: poll,
+                    timeout: 2000
+                })
+            }, 10000);
+        })();
+    </script>
+</div>

--- a/expdj/apps/turk/templates/turk/status_monitor.html
+++ b/expdj/apps/turk/templates/turk/status_monitor.html
@@ -2,10 +2,10 @@
     Experiments left in battery: <div id="remain_exp"></div><br/>
     Current assignment status: <div id="assignment_status"></div><br/>
 
-    {% if amazon_host == "mechanicalturk.amazonaws.com" %}
-    <form action="https://www.mturk.com/mturk/externalSubmit" method="POST" id="external_submit_form">
-    {% else %}
+    {% if sandbox %}
     <form action="https://workersandbox.mturk.com/mturk/externalSubmit" method="POST" id="external_submit_form">
+    {% else %}
+    <form action="https://www.mturk.com/mturk/externalSubmit" method="POST" id="external_submit_form">
     {% endif %}
             <input type="hidden" id="assignmentId" value="{{ assignment_id }}" name="assignmentId"/>
             <input type="hidden" id="workerId" value="{{ worker_id }}" name="workerId"/>

--- a/expdj/apps/turk/tests.py
+++ b/expdj/apps/turk/tests.py
@@ -8,14 +8,21 @@ import tempfile
 import boto
 import django
 from django.test import TestCase
-from django.test.utils import override_settings
 
+from expdj.apps.turk.utils import (PRODUCTION_HOST, PRODUCTION_WORKER_URL,
+                                  SANDBOX_HOST, SANDBOX_WORKER_URL,
+                                  amazon_string_to_datetime,
+                                  get_connection, get_host, get_worker_url,
+                                  is_sandbox)
+
+'''
 from cogpheno.apps.turk.utils import (PRODUCTION_HOST, PRODUCTION_WORKER_URL,
                                       SANDBOX_HOST, SANDBOX_WORKER_URL,
                                       InvalidDjurkSettings,
                                       amazon_string_to_datetime,
                                       get_connection, get_host, get_worker_url,
                                       is_sandbox)
+'''
 
 """Basic unit tests for Turk App"""
 

--- a/expdj/apps/turk/urls.py
+++ b/expdj/apps/turk/urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import url
 from django.views.generic.base import TemplateView
 
 from expdj.apps.experiments.views import sync
-from expdj.apps.turk.api_views import BatteryResultAPIList
+from expdj.apps.turk.api_views import BatteryResultAPIList, WorkerExperiments
 from expdj.apps.turk.views import (clone_hit, contact_worker, delete_hit,
                                    edit_hit, end_assignment, expire_hit,
                                    finished_view, hit_detail, manage_hit,
@@ -60,8 +60,15 @@ urlpatterns = [
     url(r'^worker/contact/(?P<aid>\d+)', contact_worker, name='contact_worker'),
 
     # New API
-    url(r'^new_api/results/(?P<bid>\d+)/$',
+    url(
+        r'^new_api/results/(?P<bid>\d+)/$',
         BatteryResultAPIList.as_view(),
         name='battery_result_api_list'
-        )
+    ),
+    url(
+        r'^new_api/worker_experiments/(?P<worker_id>[A-Za-z0-9]+)/(?P<hit_id>[A-Za-z0-9]+)/$',
+        WorkerExperiments.as_view(),
+        name='worker_experiments'
+    ),
+
 ]

--- a/expdj/apps/turk/utils.py
+++ b/expdj/apps/turk/utils.py
@@ -21,6 +21,7 @@ def to_dict(input_ordered_dict):
 
 PRODUCTION_HOST = u'mechanicalturk.amazonaws.com'
 SANDBOX_HOST = u'mechanicalturk.sandbox.amazonaws.com'
+SANDBOX_HOST = u'mturk-requester-sandbox.us-east-1.amazonaws.com'
 
 PRODUCTION_WORKER_URL = u'https://www.mturk.com'
 SANDBOX_WORKER_URL = u'https://workersandbox.mturk.com'

--- a/expdj/apps/turk/utils.py
+++ b/expdj/apps/turk/utils.py
@@ -19,8 +19,9 @@ def to_dict(input_ordered_dict):
     return json.loads(json.dumps(input_ordered_dict))
 
 
-PRODUCTION_HOST = u'mechanicalturk.amazonaws.com'
-SANDBOX_HOST = u'mechanicalturk.sandbox.amazonaws.com'
+# PRODUCTION_HOST = u'mechanicalturk.amazonaws.com'
+PRODUCTION_HOST= u'mturk-requester.us-east-1.amazonaws.com'
+# SANDBOX_HOST = u'mechanicalturk.sandbox.amazonaws.com'
 SANDBOX_HOST = u'mturk-requester-sandbox.us-east-1.amazonaws.com'
 
 PRODUCTION_WORKER_URL = u'https://www.mturk.com'

--- a/expdj/apps/turk/utils.py
+++ b/expdj/apps/turk/utils.py
@@ -4,9 +4,7 @@ import json
 import os
 
 import pandas
-from boto.mturk.connection import MTurkConnection
-from boto.mturk.price import Price
-from boto.mturk.question import ExternalQuestion
+import boto3
 from django.conf import settings
 
 from expdj.apps.experiments.models import Experiment
@@ -98,13 +96,14 @@ def get_connection(aws_access_key_id, aws_secret_access_key, hit=None):
     """Create connection based upon settings/configuration parameters"""
 
     host = get_host(hit)
-    debug = get_debug(hit)
-
-    return MTurkConnection(
+    # debug = get_debug(hit)
+    return boto3.client(
+        'mturk',
         aws_access_key_id=aws_access_key_id,
         aws_secret_access_key=aws_secret_access_key,
-        host=host,
-        debug=debug)
+        endpoint_url='https://' + host,
+        region_name='us-east-1'
+    )
 
 
 def get_app_url():

--- a/expdj/apps/turk/views.py
+++ b/expdj/apps/turk/views.py
@@ -30,7 +30,7 @@ from expdj.apps.turk.tasks import (assign_experiment_credit,
                                    get_unique_experiments)
 from expdj.apps.turk.utils import (get_connection, get_credentials, get_host,
                                    get_worker_experiments, get_worker_url)
-from expdj.settings import BASE_DIR, MEDIA_ROOT, STATIC_ROOT
+from expdj.settings import BASE_DIR, DOMAIN_NAME, MEDIA_ROOT, STATIC_ROOT
 
 media_dir = os.path.join(BASE_DIR, MEDIA_ROOT)
 
@@ -206,6 +206,7 @@ def serve_hit(request, hid):
 
         # Add variables to the context
         aws["amazon_host"] = host
+        aws["sandbox"] = hit.sandbox
         aws["uniqueId"] = result.id
 
         # If this is the last experiment, the finish button will link to a
@@ -244,7 +245,8 @@ def preview_hit(request, hid):
         context = get_amazon_variables(request)
         intro = get_battery_intro(battery)
         status_template = Template('{% include "turk/status_monitor.html" %}')
-        context["status_url"] =  "https://testing.expfactory.org/new_api/worker_experiments/{}/{}/".format('A3NNB4LWIKA3BQ', hit.mturk_id)
+        context["status_url"] =  "{}/new_api/worker_experiments/{}/{}/".format(DOMAIN_NAME, context["worker_id"], hit.mturk_id)
+        context["sandbox"] = hit.sandbox
         status_context = Context(context)
         intro.append({'title': 'Assignment Status', 'html': status_template.render(status_context)})
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,8 @@ Pillow
 python-openid
 django-sendfile
 django-polymorphic
-celery[redis]
+redis<3
+celery>=3.1.15,<4.0
 django-celery
 django-cleanup
 django-chosen

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,8 @@ requests
 requests-oauthlib
 jsonfield
 expfactory<3
-boto==2.1.1
+boto3
+boto
 django-dbbackup<2.3
 cognitiveatlas
 dropbox==1.6


### PR DESCRIPTION
Updating AWS facing api calls to boto3:
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/mturk.html

Unfortunately many of the helper functions for things like qualifications no longer exist in the new library so they need to be replaced or their outputs munged into the right form.

Tests look like they were never designed to communicate with the api. Since we use circle and djturk didn't can probably get some functional creds in the ci env to try making/destroying sandbox hits.